### PR TITLE
feat: 로그아웃 시 refreshToken 제거

### DIFF
--- a/server/src/main/java/com/ticketing/server/user/application/AuthController.java
+++ b/server/src/main/java/com/ticketing/server/user/application/AuthController.java
@@ -1,6 +1,7 @@
 package com.ticketing.server.user.application;
 
 import com.ticketing.server.user.application.request.LoginRequest;
+import com.ticketing.server.user.application.response.LogoutResponse;
 import com.ticketing.server.user.application.response.TokenDto;
 import com.ticketing.server.user.service.interfaces.AuthenticationService;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,6 +41,14 @@ public class AuthController {
 		return ResponseEntity.status(HttpStatus.OK)
 			.headers(getHttpHeaders())
 			.body(tokenDto);
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<LogoutResponse> logout(@AuthenticationPrincipal UserDetails userRequest) {
+		authenticationService.deleteRefreshToken(userRequest.getUsername());
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(LogoutResponse.from(userRequest.getUsername()));
 	}
 
 	private HttpHeaders getHttpHeaders() {

--- a/server/src/main/java/com/ticketing/server/user/application/AuthController.java
+++ b/server/src/main/java/com/ticketing/server/user/application/AuthController.java
@@ -45,10 +45,10 @@ public class AuthController {
 
 	@PostMapping("/logout")
 	public ResponseEntity<LogoutResponse> logout(@AuthenticationPrincipal UserDetails userRequest) {
-		authenticationService.deleteRefreshToken(userRequest.getUsername());
+		LogoutResponse logoutResponse = authenticationService.deleteRefreshToken(userRequest.getUsername());
 
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(LogoutResponse.from(userRequest.getUsername()));
+			.body(logoutResponse);
 	}
 
 	private HttpHeaders getHttpHeaders() {

--- a/server/src/main/java/com/ticketing/server/user/application/response/LogoutResponse.java
+++ b/server/src/main/java/com/ticketing/server/user/application/response/LogoutResponse.java
@@ -1,5 +1,6 @@
 package com.ticketing.server.user.application.response;
 
+import com.ticketing.server.global.redis.RefreshToken;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,10 +9,20 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class LogoutResponse {
 
+	private Long refreshTokenId;
 	private String email;
+	private String refreshToken;
+
+	private LogoutResponse(String email) {
+		this.email = email;
+	}
 
 	public static LogoutResponse from(String email) {
 		return new LogoutResponse(email);
+	}
+
+	public static LogoutResponse from(RefreshToken refreshToken) {
+		return new LogoutResponse(refreshToken.getId(), refreshToken.getEmail(), refreshToken.getToken());
 	}
 
 }

--- a/server/src/main/java/com/ticketing/server/user/application/response/LogoutResponse.java
+++ b/server/src/main/java/com/ticketing/server/user/application/response/LogoutResponse.java
@@ -1,0 +1,17 @@
+package com.ticketing.server.user.application.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LogoutResponse {
+
+	private String email;
+
+	public static LogoutResponse from(String email) {
+		return new LogoutResponse(email);
+	}
+
+}

--- a/server/src/main/java/com/ticketing/server/user/service/AuthenticationServiceImpl.java
+++ b/server/src/main/java/com/ticketing/server/user/service/AuthenticationServiceImpl.java
@@ -9,9 +9,9 @@ import com.ticketing.server.global.redis.RefreshRedisRepository;
 import com.ticketing.server.global.redis.RefreshToken;
 import com.ticketing.server.global.security.jwt.JwtProperties;
 import com.ticketing.server.global.security.jwt.JwtProvider;
+import com.ticketing.server.user.application.response.LogoutResponse;
 import com.ticketing.server.user.application.response.TokenDto;
 import com.ticketing.server.user.service.interfaces.AuthenticationService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -82,15 +82,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
 	@Override
 	@Transactional
-	public boolean deleteRefreshToken(String email) {
-		Optional<RefreshToken> findTokenEntity = refreshRedisRepository.findByEmail(email);
-
-		if (findTokenEntity.isPresent()) {
-			refreshRedisRepository.delete(findTokenEntity.get());
-			return true;
-		}
-
-		return false;
+	public LogoutResponse deleteRefreshToken(String email) {
+		return refreshRedisRepository.findByEmail(email)
+			.map(tokenDto -> {
+				refreshRedisRepository.delete(tokenDto);
+				return LogoutResponse.from(tokenDto);
+			}).orElseGet(() -> LogoutResponse.from(email));
 	}
 
 	private String resolveToken(String bearerToken) {

--- a/server/src/main/java/com/ticketing/server/user/service/AuthenticationServiceImpl.java
+++ b/server/src/main/java/com/ticketing/server/user/service/AuthenticationServiceImpl.java
@@ -11,6 +11,7 @@ import com.ticketing.server.global.security.jwt.JwtProperties;
 import com.ticketing.server.global.security.jwt.JwtProvider;
 import com.ticketing.server.user.application.response.TokenDto;
 import com.ticketing.server.user.service.interfaces.AuthenticationService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -77,6 +78,19 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		refreshRedisRepository.save(findTokenEntity);
 
 		return tokenDto;
+	}
+
+	@Override
+	@Transactional
+	public boolean deleteRefreshToken(String email) {
+		Optional<RefreshToken> findTokenEntity = refreshRedisRepository.findByEmail(email);
+
+		if (findTokenEntity.isPresent()) {
+			refreshRedisRepository.delete(findTokenEntity.get());
+			return true;
+		}
+
+		return false;
 	}
 
 	private String resolveToken(String bearerToken) {

--- a/server/src/main/java/com/ticketing/server/user/service/interfaces/AuthenticationService.java
+++ b/server/src/main/java/com/ticketing/server/user/service/interfaces/AuthenticationService.java
@@ -9,4 +9,6 @@ public interface AuthenticationService {
 
 	TokenDto reissueTokenDto(String bearerRefreshToken);
 
+	boolean deleteRefreshToken(String email);
+
 }

--- a/server/src/main/java/com/ticketing/server/user/service/interfaces/AuthenticationService.java
+++ b/server/src/main/java/com/ticketing/server/user/service/interfaces/AuthenticationService.java
@@ -1,5 +1,6 @@
 package com.ticketing.server.user.service.interfaces;
 
+import com.ticketing.server.user.application.response.LogoutResponse;
 import com.ticketing.server.user.application.response.TokenDto;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
@@ -9,6 +10,6 @@ public interface AuthenticationService {
 
 	TokenDto reissueTokenDto(String bearerRefreshToken);
 
-	boolean deleteRefreshToken(String email);
+	LogoutResponse deleteRefreshToken(String email);
 
 }


### PR DESCRIPTION
## 작업 분류
- [x] 기능 추가
- [ ] 코드 수정
- [ ] 환경 설정

<br/>

## 구현 세부 내용
- 로그아웃 시 refreshToken 제거

<br/>

## 코드 변경 이유 (코드 수정이 아닌 경우 공란)


<br/>

## 리뷰 요청 사항


<br/>

## 질문
Service 에서는 토큰을 지웠을 경우 `true` 를, 없는 경우에는 `false`를 리턴하도록 하였습니다.
여기서 클라이언트에 내릴 때 리프레쉬 토큰이 없어서 못지웠을 경우 상태코드를 200 말고 다른 걸 보내는 것 보다
똑같이 200 을 내리는 게 좋을 것 같아 현재 그렇게 작성했는데, 어떻게 생각하시는 지 궁금합니다!


<br/>

## 체크 리스트
- [x] 프로젝트 빌드 및 실행이 정상적으로 동작하는지 확인했습니다.
- [x] 구현 사항에 대한 테스트를 완료했습니다.
- [ ] 의도한 내용 이외에 다른 코드에는 변경 사항이 없는지 확인했습니다.
- [x] 코드 스타일을 적용하여 팀 코딩 컨벤션에 맞게 작성했습니다.
